### PR TITLE
Add Gemini API rate limiting and checkpointing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Dataset Conversion
 
 `convert_datasets.py` generates conversation data for image datasets using the Gemini Flash API.
+The script respects the API rate limit by issuing at most 12 requests per minute
+and stores progress in checkpoint files so interrupted runs can be resumed.
 
 ## Requirements
 
@@ -27,6 +29,9 @@ python convert_datasets.py --dogs1 /path/to/dogs1 \
                            --cats  /path/to/cats \
                            --out data/qwen25-dataset
 ```
+
+Checkpoint files are stored in `--out/.checkpoints`. Rerun the command to
+resume generation if it stops.
 
 The script mixes and shuffles the examples from all datasets, then writes
 `train.jsonl` and `val.jsonl` to the output directory.

--- a/convert_datasets.py
+++ b/convert_datasets.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import random
 import json
+import time
 
 from google import genai
 from google.genai import types
@@ -9,8 +10,15 @@ from google.genai import types
 
 MODEL_NAME = "gemini-2.0-flash"
 
+RATE_LIMIT_PER_MIN = 12
+_CALL_INTERVAL = 60.0 / RATE_LIMIT_PER_MIN
+_last_call_time = 0.0
+MAX_RETRIES = 3
+
 
 def generate_qa(client, image_path, label):
+    global _last_call_time
+
     with open(image_path, "rb") as f:
         data = f.read()
 
@@ -45,31 +53,58 @@ def generate_qa(client, image_path, label):
         system_instruction=[types.Part.from_text(text=system_instruction)],
     )
 
-    response = client.models.generate_content(
-        model=MODEL_NAME,
-        contents=contents,
-        config=gen_config,
-    )
+    for attempt in range(MAX_RETRIES):
+        wait = _last_call_time + _CALL_INTERVAL - time.time()
+        if wait > 0:
+            time.sleep(wait)
+        start = time.time()
+        try:
+            response = client.models.generate_content(
+                model=MODEL_NAME,
+                contents=contents,
+                config=gen_config,
+            )
+        except Exception:
+            _last_call_time = start
+            if attempt == MAX_RETRIES - 1:
+                raise
+            time.sleep(min(30, 2 ** attempt))
+            continue
+        _last_call_time = start
+        text = getattr(response, "text", None)
+        if text is None and hasattr(response, "candidates"):
+            text = response.candidates[0].text
+        if text is None:
+            text = ""
+        text = text.strip()
 
-    text = getattr(response, "text", None)
-    if text is None and hasattr(response, "candidates"):
-        text = response.candidates[0].text
-    if text is None:
-        text = ""
-    text = text.strip()
+        try:
+            data = json.loads(text)
+            q = data.get("question", "").strip()
+            a = data.get("answer", "").strip()
+            if not q or not a:
+                raise ValueError("empty response")
+            return q, a
+        except Exception:
+            if attempt == MAX_RETRIES - 1:
+                raise
+            time.sleep(min(30, 2 ** attempt))
+            continue
 
-    try:
-        data = json.loads(text)
-        return data.get("question", "").strip(), data.get("answer", "").strip()
-    except Exception:
-        lines = text.strip().splitlines()
-        question = lines[0] if lines else ""
-        answer = " ".join(lines[1:]) if len(lines) > 1 else ""
-        return question.strip(), answer.strip()
+    raise RuntimeError("Failed to generate QA after retries")
 
 
-def collect_records(client, dataset_path):
+def collect_records(client, dataset_path, checkpoint_file):
     records = []
+    processed = set()
+    if os.path.exists(checkpoint_file):
+        with open(checkpoint_file) as f:
+            for line in f:
+                if line.strip():
+                    rec = json.loads(line)
+                    records.append(rec)
+                    processed.add(rec.get("image"))
+
     parent = os.path.dirname(dataset_path)
     for root, _, files in os.walk(dataset_path):
         label = os.path.basename(root)
@@ -77,14 +112,20 @@ def collect_records(client, dataset_path):
             if name.lower().endswith((".jpg", ".jpeg", ".png", ".webp")):
                 img_path = os.path.join(root, name)
                 rel = os.path.relpath(img_path, parent).replace(os.sep, "/")
+                if rel in processed:
+                    continue
                 question, answer = generate_qa(client, img_path, label)
-                records.append({
+                rec = {
                     "image": rel,
                     "conversations": [
                         {"from": "human", "value": question},
                         {"from": "gpt", "value": answer},
                     ],
-                })
+                }
+                records.append(rec)
+                with open(checkpoint_file, "a") as cp:
+                    json.dump(rec, cp)
+                    cp.write("\n")
     return records
 
 
@@ -102,6 +143,11 @@ def main():
     )
     parser.add_argument("--val-ratio", type=float, default=0.2, help="Validation split ratio")
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--checkpoint-dir",
+        default=".checkpoints",
+        help="Directory to store intermediate records",
+    )
     args = parser.parse_args()
 
     api_key = os.environ.get("GEMINI_API_KEY")
@@ -111,10 +157,13 @@ def main():
 
     random.seed(args.seed)
 
+    cp_dir = os.path.join(args.output, args.checkpoint_dir)
+    os.makedirs(cp_dir, exist_ok=True)
+
     datasets = {
-        "dogs1": collect_records(client, args.dogs1),
-        "dogs2": collect_records(client, args.dogs2),
-        "cats": collect_records(client, args.cats),
+        "dogs1": collect_records(client, args.dogs1, os.path.join(cp_dir, "dogs1.jsonl")),
+        "dogs2": collect_records(client, args.dogs2, os.path.join(cp_dir, "dogs2.jsonl")),
+        "cats": collect_records(client, args.cats, os.path.join(cp_dir, "cats.jsonl")),
     }
 
     limit = min(len(v) for v in datasets.values())


### PR DESCRIPTION
## Summary
- limit Gemini API calls to 12 per minute
- retry on failure and resume from checkpoints
- document checkpointing and rate limiting

## Testing
- `python -m py_compile convert_datasets.py`

------
https://chatgpt.com/codex/tasks/task_e_686ba71361088326ad6d328bfceec81a