### PR TITLE
Use inline_data for images

### DIFF
--- a/convert_datasets.py
+++ b/convert_datasets.py
@@ -25,7 +25,14 @@ def generate_qa(client, image_path, label):
     contents = [
         types.Content(
             role="user",
-            parts=[types.Part.from_data(mime_type="image/jpeg", data=data)],
+            parts=[
+                types.Part(
+                    inline_data=genai.types.Blob(
+                        mime_type="image/jpeg",
+                        data=data,
+                    )
+                )
+            ],
         ),
     ]
 


### PR DESCRIPTION
## Summary
- use `inline_data` to create `types.Part` for Gemini API

## Testing
- `python -m py_compile convert_datasets.py`


------
https://chatgpt.com/codex/tasks/task_e_686bb19aec448326822338e31821d9b4